### PR TITLE
fix lab1 building software guide

### DIFF
--- a/lab1.md
+++ b/lab1.md
@@ -106,9 +106,9 @@ docker run -it --rm -p 6080:6080 -p 3333:3333 -v %cd%:/home/dev/demo:Z ibex
 To build the software use the following commands in your terminal:
 ```bash
 cd /home/dev/demo
-mkdir -p sw/build
-pushd sw/build
-cmake ..
+mkdir -p sw/build/c
+pushd sw/build/c
+cmake ../../c
 make
 popd
 ```


### PR DESCRIPTION
Change building software guide of Lab 1 due to the structure sw/ directory (before building software):
sw/
- c
- common
- rust
